### PR TITLE
Add git-localprune command

### DIFF
--- a/bin/git-lprune
+++ b/bin/git-lprune
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -eo pipefail
+
+git for-each-ref --format '%(upstream:track) %(refname:short)' \
+  | grep '^\[gone\]' \
+  | cut -d' ' -f2 -

--- a/install
+++ b/install
@@ -16,6 +16,7 @@ if [ ! -d "$HOME/bin" ] ; then
 fi
 
 stow -v -t ~ --dotfiles git tmux vim zsh
+stow -v -t ~/bin bin
 
 if [ ! -f "$HOME/.zsh_plugins.sh" ] ; then
   antibody bundle < ~/.zsh_plugins > ~/.zsh_plugins.sh


### PR DESCRIPTION
This is a tool that I've been using at work for a while to clean up branches that have already been deleted 
in the remote. Basically just "list any branch that is marked 'gone'". Typical usage is 

```sh
g lprune | xargs git branch -d
```

but I didn't actually include that as part of the script because there's other reasons that I might want to know if a 
branch was deleted upstream, or I might need to use `git branch -D` if I know a certain branch was deleted without 
merging.
